### PR TITLE
Patch for systems lacking WMIC

### DIFF
--- a/nfs_hits_cpu90_fix.cmd
+++ b/nfs_hits_cpu90_fix.cmd
@@ -5,8 +5,8 @@ set "CPU_Threads=0"
 set "UserCFGFileCDDir=%~dp0"
 set "UserCFGFileName=user.cfg"
 set "UserCFGFile=%UserCFGFileCDDir%%UserCFGFileName%"
-for /f "tokens=2 delims= " %%a in ('"wmic CPU Get DeviceID,NumberOfCores,NumberOfLogicalProcessors"') do set "CPU_Cores=%%a"
-for /f "tokens=3 delims= " %%a in ('"wmic CPU Get DeviceID,NumberOfCores,NumberOfLogicalProcessors"') do set "CPU_Threads=%%a"
+for /f "tokens=*" %%a in ('powershell -Command "Get-CimInstance -ClassName Win32_Processor | Select-Object -ExpandProperty NumberOfCores"') do set "CPU_Cores=%%a"
+for /f "tokens=*" %%a in ('powershell -Command "Get-CimInstance -ClassName Win32_Processor | Select-Object -ExpandProperty NumberOfLogicalProcessors"') do set "CPU_Threads=%%a"
 if %CPU_Cores% == 0 goto oops_a
 echo.
 echo    Fix 90%% CPU load!


### PR DESCRIPTION
Windows 11 24H2 has recently removed WMIC, causing the script to fail once ran. Moving the command over to Get-CimInstance allows the script to work on all modern platforms with PowerShell. Fixes #2